### PR TITLE
Added dockerfile for easy running.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:2-slim
+
+WORKDIR /srv
+ADD . /srv/ftp-gov-grab/
+
+RUN apt-get update \
+	&& apt-get install -y rsync wget \
+	&& pip install seesaw warc requests
+
+RUN wget https://launchpad.net/wpull/trunk/v2.0.1/+download/wpull-2.0.1-linux-x86_64-3.4.3-20161230193838.zip \
+	&& python -c "import zipfile; f=zipfile.ZipFile('wpull-2.0.1-linux-x86_64-3.4.3-20161230193838.zip'); f.extractall('./')" \
+	&& chmod +x ./wpull \
+	&& mv ./wpull /usr/bin \
+	&& rm -f wpull-2.0.1-linux-x86_64-3.4.3-20161230193838.zip
+
+ENTRYPOINT ["run-pipeline", "/srv/ftp-gov-grab/pipeline.py"]
+
+EXPOSE 8001


### PR DESCRIPTION
I've added a dockerfile which makes the project a bit easier to get running.

This could be used as the base for generating a docker image, so that people can run it simply by going:

```bash
$ docker pull ftp-gov-grab
$ docker run --rm ftp-gov-grab:latest
```

Or something like that.